### PR TITLE
Fix spelling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
 	"url": "http://owntracks.org/",
 	"license": "free",
 	"maintainer": {
-		"name": "Titus PiJean",
+		"name": "tituspijean",
 		"email": "tituspijean@outlook.com",
 		"url": "https://github.com/tituspijean/owntracks_ynh"
 	},


### PR DESCRIPTION
to be like:

- https://github.com/YunoHost-Apps/cowyo_ynh/blob/master/manifest.json
- https://github.com/YunoHost-Apps/grav_ynh/blob/master/manifest.json