### PR TITLE
add ability to make owntracks public

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -51,7 +51,7 @@
 					"fr": "Choisissez un utilisateur pour Owntracks"
 				},
 				"help": {
-					"en": "If public, this user trace will be public ",
+					"en": "If public, this user's trace will be public.",
 					"fr": "Si publique, les traces de cet utilisateur seront publiques."
 				},
 				"optional": "true"

--- a/manifest.json
+++ b/manifest.json
@@ -42,6 +42,32 @@
 				},
 				"example": "/owntracks",
 				"default": "/owntracks"
+			},
+			{
+				"name": "user",
+				"type": "user",
+				"ask": {
+					"en": "Choose an user for Owntracks",
+					"fr": "Choisissez un utilisateur pour Owntracks"
+				},
+				"help": {
+					"en": "If public, this user trace will be public ",
+					"fr": "Si publique, les traces de cet utilisateur seront publiques."
+				},
+				"optional": "true"
+			},
+			{
+				"name": "is_public",
+				"type": "boolean",
+				"ask": {
+					"en": "Is it a public application?",
+					"fr": "Est-ce une application publique ?"
+				},
+				"help": {
+					"en": "If public, anyone will be able to see the owntracks record from specified user.",
+					"fr": "Si publique, quiconque aura accès aux traces owntracks de l'utilisateur specifié."
+				},
+				"default": false
 			}
 		]
 	}

--- a/scripts/install
+++ b/scripts/install
@@ -22,6 +22,8 @@ ynh_abort_if_errors
 
 domain=$YNH_APP_ARG_DOMAIN
 path_url=$YNH_APP_ARG_PATH
+user=$YNH_APP_ARG_USER
+is_public=$YNH_APP_ARG_IS_PUBLIC
 
 # This is a multi-instance app, meaning it can be installed several times independently
 # The id of the app as stated in the manifest is available as $YNH_APP_ID
@@ -41,6 +43,11 @@ app=$YNH_APP_INSTANCE_NAME
 
 final_path=/var/www/$app
 test ! -e "$final_path" || ynh_die "This path already contains a folder"
+
+if [ $is_public -eq 1 ] && [ ! $user ]
+then
+    ynh_die "You must set up an user if owntracks is public"
+fi
 
 # Normalize the url path syntax
 path_url=$(ynh_normalize_url_path $path_url)
@@ -113,6 +120,11 @@ ynh_mysql_connect_as $app $db_pwd $db_name < "$final_path/sql/schema.sql"
 ynh_replace_string "__USER__" "$app" "$final_path/config.inc.php"
 ynh_replace_string "__DB_PWD__" "$db_pwd" "$final_path/config.inc.php"
 
+if [ $is_public -eq 1 ]
+then
+    ynh_replace_string "\$_SERVER\['PHP_AUTH_USER'\]" "$user" "$final_path/map_points.php"
+    ynh_app_setting_set $app unprotected_uris "/"
+fi
 #=================================================
 # STORE THE CHECKSUM OF THE CONFIG FILE
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -125,6 +125,7 @@ then
     ynh_replace_string "\$_SERVER\['PHP_AUTH_USER'\]" "$user" "$final_path/map_points.php"
     ynh_app_setting_set $app unprotected_uris "/"
 fi
+
 #=================================================
 # STORE THE CHECKSUM OF THE CONFIG FILE
 #=================================================


### PR DESCRIPTION
This commit allow a config where owntracks web application become
public.

A parameter is_public can be set to true to make it public.
An user is selected to be displayed at install.